### PR TITLE
Working on persisting sound mixer properties

### DIFF
--- a/Mine-Mayhem/Assets/Resources/MineMayhemMasterMix.mixer
+++ b/Mine-Mayhem/Assets/Resources/MineMayhemMasterMix.mixer
@@ -33,6 +33,20 @@ AudioMixerEffectController:
   m_SendTarget: {fileID: 0}
   m_EnableWetMix: 0
   m_Bypass: 0
+--- !u!245 &-4295948302177483933
+AudioMixerSnapshotController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Custom
+  m_AudioMixer: {fileID: 24100000}
+  m_SnapshotID: edf36aced2b9cd64484a42a5df4fb727
+  m_FloatValues:
+    32301664b40d1fc429fe721e378edcd9: 2.850226
+    30e75f49efe4f5a4b9b8ee4738fd6d8a: -10.867776
+    fa933cfe3a879304eaa871cdbc93cf37: -3.1841109
+  m_TransitionOverrides: {}
 --- !u!244 &-2492938048151836122
 AudioMixerEffectController:
   m_ObjectHideFlags: 3
@@ -58,6 +72,7 @@ AudioMixerController:
   m_MasterGroup: {fileID: 24300002}
   m_Snapshots:
   - {fileID: 24500006}
+  - {fileID: -4295948302177483933}
   m_StartSnapshot: {fileID: 24500006}
   m_SuspendThreshold: -80
   m_EnableSuspend: 1
@@ -116,7 +131,7 @@ AudioMixerSnapshotController:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Snapshot
+  m_Name: Default
   m_AudioMixer: {fileID: 24100000}
   m_SnapshotID: 5a2204b10be63544ea485cc42a120600
   m_FloatValues:

--- a/Mine-Mayhem/Assets/Resources/Prefabs/Gem.prefab
+++ b/Mine-Mayhem/Assets/Resources/Prefabs/Gem.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6081831998492794069}
   - component: {fileID: 6081831998492794058}
   - component: {fileID: 5266509296758065546}
+  - component: {fileID: -9028377496138620087}
   m_Layer: 0
   m_Name: Gem
   m_TagString: Untagged
@@ -154,4 +155,100 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PickUpType: 1
-  gemPickup: {fileID: 8300000, guid: 2d481372860dc3a49ab70e04361ae843, type: 3}
+--- !u!82 &-9028377496138620087
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6081831998492794059}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 4297275597100935204, guid: 892d3ed5bcbb28f4794402fe5f85e79b,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: 2d481372860dc3a49ab70e04361ae843, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Mine-Mayhem/Assets/Resources/Prefabs/MinerChar.prefab
+++ b/Mine-Mayhem/Assets/Resources/Prefabs/MinerChar.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 6278999797366326145}
   - component: {fileID: 7774946003657464871}
   - component: {fileID: 889142004}
+  - component: {fileID: 1998357366}
   m_Layer: 0
   m_Name: JumpExplosion
   m_TagString: Untagged
@@ -118,6 +119,103 @@ CapsuleCollider2D:
   m_Offset: {x: -0.08700778, y: -0.092796385}
   m_Size: {x: 1.8173339, y: 0.75250816}
   m_Direction: 1
+--- !u!82 &1998357366
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 533135462556788734}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 4297275597100935204, guid: 892d3ed5bcbb28f4794402fe5f85e79b,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: dc3e228c655ca384e8a3dc3898717b4d, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.15
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1469858872472482503
 GameObject:
   m_ObjectHideFlags: 0
@@ -207,6 +305,7 @@ GameObject:
   - component: {fileID: 6615952671953321165}
   - component: {fileID: 964777897998480931}
   - component: {fileID: 6788220788188354268}
+  - component: {fileID: -5329393242688417499}
   m_Layer: 0
   m_Name: MinerChar
   m_TagString: Untagged
@@ -309,6 +408,8 @@ MonoBehaviour:
   worldLayer:
     serializedVersion: 2
     m_Bits: 256
+  boomDeathClip: {fileID: 8300000, guid: ba8e5c2372d362f4284b119af33bdd41, type: 3}
+  spikeDeathClip: {fileID: 8300000, guid: a95a49e8527c2ab44a18abf1ab9bfdb7, type: 3}
 --- !u!50 &6615952671953321165
 Rigidbody2D:
   serializedVersion: 4
@@ -365,3 +466,100 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!82 &-5329393242688417499
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4671418477395463648}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 4297275597100935204, guid: 892d3ed5bcbb28f4794402fe5f85e79b,
+    type: 2}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Mine-Mayhem/Assets/Resources/Scripts/GameManager.cs
+++ b/Mine-Mayhem/Assets/Resources/Scripts/GameManager.cs
@@ -230,6 +230,21 @@ public static class GameManager
                 }
             }
 
+            switch (StarsAcquired)
+            {
+                case 1:
+                    SoundManager.PlaySound(SoundManager.Win1);
+                    break;
+
+                case 2:
+                    SoundManager.PlaySound(SoundManager.Win2);
+                    break;
+
+                case 3:
+                    SoundManager.PlaySound(SoundManager.Win3);
+                    break;
+            }
+
             // Assign the awarded stars to the level and unlock the next level.
             LevelInformation.Levels[LevelIndex].stars = (Level.LevelStars)StarsAcquired;
             if (LevelIndex != LevelInformation.Levels.Length - 1)

--- a/Mine-Mayhem/Assets/Resources/Scripts/SoundManager.cs
+++ b/Mine-Mayhem/Assets/Resources/Scripts/SoundManager.cs
@@ -6,40 +6,67 @@ public static class SoundManager
     /// Main Menu Transition: QuickTransition4, 
     /// 
 
-    private static AudioSource MusicSource { get; set; }
-    private static AudioSource SFXSource { get; set; }
+    public static AudioSource MusicSource { get; private set; }
+    public static AudioSource SFXSource { get; private set; }
+
+    public static int MasterMusicVolume { get; private set; }
+    public static int MasterSoundVolume { get; private set; }
 
     public static AudioClip Win1 { get; private set; } // Positive 5
     public static AudioClip Win2 { get; private set; } // Positive 4
     public static AudioClip Win3 { get; private set; } // Positive 3
-    public static AudioClip SpikeDeath { get; private set; } // Negative 5
-    public static AudioClip BoomDeath { get; private set; } // Negative 6
-    public static AudioClip BoomJump { get; private set; } // RoundHitFire
-    public static AudioClip TNT_Explosion { get; private set; } // NukeMissile_CartoonyExplosion
-    public static AudioClip GemPickup { get; private set; } // Coins (24)
-    public static AudioClip ButtonClick { get; private set; } // PrizeWheelSpin2Tick
-    public static AudioClip MainMenuTransition { get; private set; } // Quick Transition 4
+    public static AudioClip LevelMusic1to5 { get; private set; } //CGM 11
+    public static AudioClip LevelMusic6to10 { get; private set; } //CGM 8
+    public static AudioClip LevelMusic11to15 { get; private set; } //CGM 12
+    public static AudioClip LevelMusic16to20 { get; private set; } //CGM 6
+    public static AudioClip LevelMusic21to25 { get; private set; } //CGM 3
+    public static AudioClip LevelMusic26to30 { get; private set; } //CGM 1
+
+    //public static AudioClip SpikeDeath { get; private set; } // Negative 5
+    //public static AudioClip BoomDeath { get; private set; } // Negative 6
+    //public static AudioClip BoomJump { get; private set; } // RoundHitFire
+    //public static AudioClip TNT_Explosion { get; private set; } // NukeMissile_CartoonyExplosion
+    //public static AudioClip GemPickup { get; private set; } // Coins (24)
+    //public static AudioClip ButtonClick { get; private set; } // PrizeWheelSpin2Tick
+   //public static AudioClip MainMenuTransition { get; private set; } // Quick Transition 4
 
     static SoundManager()
     {
-
+        MasterMusicVolume = 10;
+        MasterSoundVolume = 10;
         Win1 = GetClip("SFX/Victory/Positive 5");
         Win2 = GetClip("SFX/Victory/Positive 4");
         Win3 = GetClip("SFX/Victory/Positive 3");
-        SpikeDeath = GetClip("SFX/Defeat/Negative 5");
-        BoomDeath = GetClip("SFX/Defeat/Negative 6");
-        BoomJump = GetClip("SFX/Booms/Jump/RoundHitFire");
+        LevelMusic1to5 = GetClip("Music/Casual Game Music 11");
+        LevelMusic6to10 = GetClip("Music/Casual Game Music 08");
+        LevelMusic11to15 = GetClip("Music/Casual Game Music 12");
+        LevelMusic16to20 = GetClip("Music/Casual Game Music 06");
+        LevelMusic21to25 = GetClip("Music/Casual Game Music 03");
+        LevelMusic26to30 = GetClip("Mucis/Casual Game Music 01");
+        //SpikeDeath = GetClip("SFX/Defeat/Negative 5");
+        //BoomDeath = GetClip("SFX/Defeat/Negative 6");
+        //BoomJump = GetClip("SFX/Booms/Jump/RoundHitFire");
         //TNT_Explosion = GetClip("SFX/Booms/TNT/NukeMissle_CartoonyExplosion");
-        GemPickup = GetClip("SFX/Pickup/Coins (24)");
-        ButtonClick = GetClip("SFX/UI/Prize Wheel Spin 2 Tick");
-        MainMenuTransition = GetClip("SFX/UI/Quick Transition 4");
+        //GemPickup = GetClip("SFX/Pickup/Coins (24)");
+        //ButtonClick = GetClip("SFX/UI/Prize Wheel Spin 2 Tick");
+        //MainMenuTransition = GetClip("SFX/UI/Quick Transition 4");
+    }
+
+    public static void SetMasterVolumes(int _music, int _sound)
+    {
+        if(MasterMusicVolume != _music)
+        {
+            MasterMusicVolume = _music;
+        }
+
+        if(MasterSoundVolume != _sound)
+        {
+            MasterSoundVolume = _sound;
+        }
     }
 
     public static void PlaySound(AudioClip clip)
     {
-        Debug.Log($"Clip being played: {clip}.");
-        //SFXSource.PlayOneShot(clip);
-
         if (!SFXSource.isPlaying)
         {
             SFXSource.PlayOneShot(clip);

--- a/Mine-Mayhem/Assets/Resources/Scripts/TempVolumeControl.cs
+++ b/Mine-Mayhem/Assets/Resources/Scripts/TempVolumeControl.cs
@@ -11,9 +11,14 @@ public class TempVolumeControl : MonoBehaviour
     [SerializeField] AudioMixer mixer;
     //Initialize volume
     [SerializeField] int _musicVolume  = 10;
+    public int MusicVolume { get { return _musicVolume; } }
+
     [SerializeField] int _soundVolume  = 10;
+    public int SoundVolume { get { return _soundVolume; } }
     //for incrementing the volume up and down
     [SerializeField] int _increment = 1;
+
+    public float testFloat;
 
     //To get the Volume to scale properly interact with the audio mixer
     [SerializeField] float _multiplier = 30.0f;
@@ -26,6 +31,22 @@ public class TempVolumeControl : MonoBehaviour
     void Update()
     {
         ClampVolume();
+        //DisplayVolume();
+        
+    }
+
+    public void SetMixerDisplayVolumes(int _music, int _sound)
+    {
+        if (_musicVolume != _music)
+        {
+            _musicVolume = _music;
+        }
+
+        if (_soundVolume != _music)
+        {
+            _soundVolume = _sound;
+        }
+
         DisplayVolume();
     }
 
@@ -43,17 +64,22 @@ public class TempVolumeControl : MonoBehaviour
 
                 //turn int into a decimal
                 float value = (_musicVolume / 10.0f);
+                float newValue;
 
                 //This just allows for audio to be muted while volume is set to 0
                 if (_soundVolume != 0)
                 {
-                    mixer.SetFloat("MusicVolume", Mathf.Log10(value) * _multiplier);
+                    newValue = Mathf.Log10(value) * _multiplier;
+                    mixer.SetFloat("MusicVolume", newValue);
                 }
                 else
                 {
-                    mixer.SetFloat("MusicVolume", -80.0f);
+                    newValue = -80.0f;
+                    mixer.SetFloat("MusicVolume", newValue);
                 }
             }
+
+            DisplayVolume();
         }
         //Check if the target  Audio group is the Sound group
         else if (_audioGroup == "Sound")
@@ -66,17 +92,22 @@ public class TempVolumeControl : MonoBehaviour
 
                 //turn int into a decimal
                 float value = (_soundVolume / 10.0f);
+                float newValue;
 
                 //This just allows for audio to be muted while volume is set to 0
                 if (_soundVolume != 0)
                 {
-                    mixer.SetFloat("SfxVolume", Mathf.Log10(value) * _multiplier);
+                    newValue = Mathf.Log10(value) * _multiplier;
+                    mixer.SetFloat("SfxVolume", newValue);
                 }
                 else
                 {
-                    mixer.SetFloat("SfxVolume", -80.0f);
+                    newValue = -80.0f;
+                    mixer.SetFloat("SfxVolume", newValue);
                 }
             }
+
+            DisplayVolume();
         }
     }
 
@@ -94,17 +125,22 @@ public class TempVolumeControl : MonoBehaviour
                 
                 //turn int into a decimal
                 float value = (_musicVolume / 10.0f);
+                float newValue;
 
                 //This just allows for audio to be muted while volume is set to 0
                 if (_musicVolume != 0)
                 {
-                    mixer.SetFloat("MusicVolume", Mathf.Log10(value) * _multiplier);
+                    newValue = Mathf.Log10(value) * _multiplier;
+                    mixer.SetFloat("MusicVolume", newValue);
                 }
                 else
                 {
-                    mixer.SetFloat("MusicVolume", -80.0f);
+                    newValue = -80.0f;
+                    mixer.SetFloat("MusicVolume", newValue);
                 }
             }
+
+            DisplayVolume();
         }
         //Check if the target  Audio group is the Sound group
         else if (_audioGroup == "Sound")
@@ -117,17 +153,22 @@ public class TempVolumeControl : MonoBehaviour
 
                 //turn int into a decimal
                 float value = (_soundVolume / 10.0f);
+                float newValue;
 
                 //This just allows for audio to be muted while volume is set to 0
                 if (_soundVolume != 0)
                 {
-                    mixer.SetFloat("SfxVolume", Mathf.Log10(value) * _multiplier);
+                    newValue = Mathf.Log10(value) * _multiplier;
+                    mixer.SetFloat("SfxVolume", newValue);
                 }
                 else
                 {
-                    mixer.SetFloat("SfxVolume", -80.0f);
+                    newValue = -80.0f;
+                    mixer.SetFloat("SfxVolume", newValue);
                 }
             }
+
+            DisplayVolume();
         }
     }
     

--- a/Mine-Mayhem/Assets/Resources/Scripts/UI/MM_UI.cs
+++ b/Mine-Mayhem/Assets/Resources/Scripts/UI/MM_UI.cs
@@ -60,7 +60,7 @@ public class MM_UI : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+        DisableIntroQuipOnButtonPress();
     }
 
     private void OnDisable()
@@ -72,6 +72,27 @@ public class MM_UI : MonoBehaviour
         GameManager.OnToggleDeathPanel -= ToggleFailPanelEvent;
         GameManager.OnToggleSuccessPanel -= ToggleSuccessPanelEvent;
         GameManager.OnToggleGameFinishedPanel -= ToggleGameFinishedPanelEvent;
+    }
+
+    private void DisableIntroQuipOnButtonPress()
+    {
+        if (IntroQuipActive)
+        {
+            if (Input.anyKeyDown)
+            {
+                IntroQuipActive = false;
+                ToggleIntroQuip(IntroQuipActive);
+            }
+        }
+    }
+
+    private void ToggleIntroQuip(bool value)
+    {
+        if(IntroQuipActive != value)
+            IntroQuipActive = value;
+
+        if (introQuip.gameObject.activeSelf != IntroQuipActive)
+            introQuip.gameObject.SetActive(IntroQuipActive);
     }
 
     private void ToggleHPEvent(bool value)
@@ -185,6 +206,7 @@ public class MM_UI : MonoBehaviour
     private void LevelStartEvent()
     {
         //Debug.Log("This is the LevelStartEvent.");
+        ToggleIntroQuip(true);
         hp.lifeBar.fillAmount = GameManager.Player.curPlayerHealth / GameManager.Player.maxPlayerHealth;
     }
 

--- a/Mine-Mayhem/Assets/Resources/Scripts/UI/MainMenu.cs
+++ b/Mine-Mayhem/Assets/Resources/Scripts/UI/MainMenu.cs
@@ -22,13 +22,8 @@ public class MainMenu : MonoBehaviour
     public GameObject levelLock;
     public Image[] levelStarIMGs;
 
-    [Space(10)]
-    [SerializeField] private int musicVolume;
-    [SerializeField] private int maxMusicVolume;
-    [SerializeField] private int sfxVolume;
-    [SerializeField] private int maxSFXVolume;
-    public TextMeshProUGUI mvText;
-    public TextMeshProUGUI sfxText;
+    private TempVolumeControl MixerControl { get { return GetComponent<TempVolumeControl>(); } }
+
 
     // Start is called before the first frame update
     void Start()
@@ -37,11 +32,6 @@ public class MainMenu : MonoBehaviour
         htpIndex = 0;
         levelIndex = 1;
         EditLevelInfo(LevelInformation.Levels[levelIndex].displayName, LevelInformation.Levels[levelIndex].levelLocked, LevelInformation.Levels[levelIndex].stars);
-
-        musicVolume = maxMusicVolume;
-        sfxVolume = maxSFXVolume;
-        EditMVText();
-        EditSFXText();
     }
 
     private void EditLevelInfo(string levelName, bool levelLocked, Level.LevelStars rating)
@@ -117,26 +107,6 @@ public class MainMenu : MonoBehaviour
                     }
                 }
                 break;
-        }
-    }
-
-    private void EditMVText()
-    {
-        string newText = $"Music: {musicVolume}";
-
-        if(mvText.text != newText)
-        {
-            mvText.text = newText;
-        }
-    }
-
-    private void EditSFXText()
-    {
-        string newText = $"SFX: {sfxVolume}";
-
-        if(sfxText.text != newText)
-        {
-            sfxText.text = newText;
         }
     }
 
@@ -241,6 +211,8 @@ public class MainMenu : MonoBehaviour
         }
         else if (MainMenuAnimator.GetCurrentAnimatorStateInfo(0).IsName("Settings"))
         {
+            // Save volumes from TempVolumeControl to SoundManager Master Volumes
+            SoundManager.SetMasterVolumes(MixerControl.MusicVolume, MixerControl.SoundVolume);
             MainMenuAnimator.SetTrigger("LeaveSettings");
         }
     }
@@ -401,46 +373,7 @@ public class MainMenu : MonoBehaviour
 
     public void SettingsButton()
     {
+        MixerControl.SetMixerDisplayVolumes(SoundManager.MasterMusicVolume, SoundManager.MasterSoundVolume);
         MainMenuAnimator.SetTrigger("ToSettings");
-    }
-
-    public void MusicVolumeDecrementButton()
-    {
-        musicVolume--;
-        if(musicVolume < 0)
-        {
-            musicVolume = 0;
-        }
-        EditMVText();
-    }
-
-    public void MusicVolumeIncrementButton()
-    {
-        musicVolume++;
-        if(musicVolume > maxMusicVolume)
-        {
-            musicVolume = maxMusicVolume;
-        }
-        EditMVText();
-    }
-
-    public void SFXVolumeDecrementButton()
-    {
-        sfxVolume--;
-        if(sfxVolume < 0)
-        {
-            sfxVolume = 0;
-        }
-        EditSFXText();
-    }
-
-    public void SFXVolumeIncrementButton()
-    {
-        sfxVolume++;
-        if(sfxVolume > maxSFXVolume)
-        {
-            sfxVolume = maxSFXVolume;
-        }
-        EditSFXText();
     }
 }

--- a/Mine-Mayhem/Assets/Scenes/Menus/MainMenu.unity
+++ b/Mine-Mayhem/Assets/Scenes/Menus/MainMenu.unity
@@ -269,6 +269,91 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1748272802}
     m_Modifications:
+    - target: {fileID: 1228903442, guid: 237e2d40900de4d448bbf38728bf2920, type: 3}
+      propertyPath: defaultSnapshot
+      value: 
+      objectReference: {fileID: 24500006, guid: 892d3ed5bcbb28f4794402fe5f85e79b,
+        type: 2}
+    - target: {fileID: 1228903442, guid: 237e2d40900de4d448bbf38728bf2920, type: 3}
+      propertyPath: customSnapshot
+      value: 
+      objectReference: {fileID: -4295948302177483933, guid: 892d3ed5bcbb28f4794402fe5f85e79b,
+        type: 2}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2100443414}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Play
+      objectReference: {fileID: 0}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1542604358}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: DecreaseVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 272933389355343815, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
+      value: Music
+      objectReference: {fileID: 0}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2100443414}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Play
+      objectReference: {fileID: 0}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1542604358}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: DecreaseVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 838625068724223248, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
+      value: Sound
+      objectReference: {fileID: 0}
     - target: {fileID: 3735073946191586578, guid: 237e2d40900de4d448bbf38728bf2920,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -379,6 +464,76 @@ PrefabInstance:
       propertyPath: m_Name
       value: Main Menu
       objectReference: {fileID: 0}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2100443414}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Play
+      objectReference: {fileID: 0}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1542604358}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: IncreaseVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4833402152111590550, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
+      value: Sound
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2100443414}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Play
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1542604358}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: IncreaseVolume
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777171450709059653, guid: 237e2d40900de4d448bbf38728bf2920,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
+      value: Music
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 237e2d40900de4d448bbf38728bf2920, type: 3}
 --- !u!1 &1158044231
@@ -453,6 +608,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1542604358 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1228903442, guid: 237e2d40900de4d448bbf38728bf2920,
+    type: 3}
+  m_PrefabInstance: {fileID: 811876653}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf72842fc0a92a9428781e46e3a3c39e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1748272799
 GameObject:
   m_ObjectHideFlags: 0
@@ -661,6 +828,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!82 &2100443414 stripped
+AudioSource:
+  m_CorrespondingSourceObject: {fileID: 798795971, guid: 237e2d40900de4d448bbf38728bf2920,
+    type: 3}
+  m_PrefabInstance: {fileID: 811876653}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8293809237747958951
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -668,6 +841,19 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1224562181, guid: b0477c5621aaeed4fbc2c2f14f6423c1, type: 3}
+      propertyPath: m_PlayOnAwake
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2008550056, guid: b0477c5621aaeed4fbc2c2f14f6423c1, type: 3}
+      propertyPath: OutputAudioMixerGroup
+      value: 
+      objectReference: {fileID: 4297275597100935204, guid: 892d3ed5bcbb28f4794402fe5f85e79b,
+        type: 2}
+    - target: {fileID: 2008550056, guid: b0477c5621aaeed4fbc2c2f14f6423c1, type: 3}
+      propertyPath: m_PlayOnAwake
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3513391599363832471, guid: b0477c5621aaeed4fbc2c2f14f6423c1,
         type: 3}
       propertyPath: m_Name

--- a/Mine-Mayhem/Assets/Scenes/PlayableLevels/MM_Level1.unity
+++ b/Mine-Mayhem/Assets/Scenes/PlayableLevels/MM_Level1.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 0
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -9232,11 +9232,6 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 6.407615
       objectReference: {fileID: 0}
@@ -9252,11 +9247,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
-        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -9269,6 +9259,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2227743004489404773, guid: 721363655e5c9c84d8e7353a4d171a13,
         type: 3}


### PR DESCRIPTION
- Minor edits to MM_UI.

- Main Menu saves sound mixer volumes to SoundManager when transitioning to main menu from settings menu.

- Main Menu edits sound mixer volumes in settings menu from values stored in SoundManager.

- Added method to TempVolumeControl.cs to modify the volume numbers when transitioning to the settings menu (to keep numbers displayed persistent after playing a level and moving back to the Main Menu)

- Added Method to SoundManager to store master volumes to SoundManager when transitioning from settings menu back to main menu.

- Added Gem collection conditions to Collectible.cs to properly play collectible sound and destroy object at the end of the audio clip.